### PR TITLE
Improve postgres maintenance logging

### DIFF
--- a/scripts/postgres-maintenance/backup.sh
+++ b/scripts/postgres-maintenance/backup.sh
@@ -1,22 +1,40 @@
 #!/bin/sh
 set -euo pipefail
 
+log() {
+  echo "[$(date -Iseconds)] [backup] $*"
+}
+
+cleanup() {
+  status=$?
+  if [ $status -eq 0 ]; then
+    log "Backup completed successfully"
+  else
+    log "Backup failed with exit code $status"
+  fi
+}
+
+log "Starting backup script"
+trap cleanup EXIT
+
 if [ -z "${POSTGRES_BACKUP_FILE:-}" ]; then
-  echo "POSTGRES_BACKUP_FILE is not set" >&2
+  log "POSTGRES_BACKUP_FILE is not set"
   exit 1
 fi
 
 if [ -z "${POSTGRES_USER:-}" ] || [ -z "${POSTGRES_PASSWORD:-}" ] || [ -z "${POSTGRES_DB:-}" ]; then
-  echo "POSTGRES_USER, POSTGRES_PASSWORD, and POSTGRES_DB must be set" >&2
+  log "POSTGRES_USER, POSTGRES_PASSWORD, and POSTGRES_DB must be set"
   exit 1
 fi
 
 BACKUP_DIR="$(dirname "${POSTGRES_BACKUP_FILE}")"
+log "Ensuring backup directory ${BACKUP_DIR} exists"
 mkdir -p "${BACKUP_DIR}"
 TEMP_FILE="${POSTGRES_BACKUP_FILE}.tmp"
 
 export PGPASSWORD="${POSTGRES_PASSWORD}"
 
+log "Running pg_dump for ${POSTGRES_DB} on ${POSTGRES_HOST:-postgres}:${POSTGRES_PORT:-5432}"
 pg_dump \
   --clean \
   --if-exists \
@@ -27,6 +45,7 @@ pg_dump \
   --dbname "${POSTGRES_DB}" \
   --file "${TEMP_FILE}"
 
+log "Moving temporary backup to ${POSTGRES_BACKUP_FILE}"
 mv "${TEMP_FILE}" "${POSTGRES_BACKUP_FILE}"
 
-echo "[$(date -Iseconds)] Backup written to ${POSTGRES_BACKUP_FILE}"
+log "Backup written to ${POSTGRES_BACKUP_FILE}"

--- a/scripts/postgres-maintenance/entrypoint.sh
+++ b/scripts/postgres-maintenance/entrypoint.sh
@@ -1,32 +1,42 @@
 #!/bin/sh
 set -euo pipefail
 
+log() {
+  echo "[$(date -Iseconds)] [entrypoint] $*"
+}
+
 COMMAND="${1:-cron}"
+log "Container started with command: ${COMMAND}"
 
 case "${COMMAND}" in
   cron)
+    log "Configuring cron backup schedule"
     if [ -z "${POSTGRES_BACKUP_CRON:-}" ]; then
-      echo "POSTGRES_BACKUP_CRON is not set" >&2
+      log "POSTGRES_BACKUP_CRON is not set"
       exit 1
     fi
     if [ -z "${POSTGRES_BACKUP_FILE:-}" ]; then
-      echo "POSTGRES_BACKUP_FILE is not set" >&2
+      log "POSTGRES_BACKUP_FILE is not set"
       exit 1
     fi
 
-    echo "${POSTGRES_BACKUP_CRON} /usr/local/bin/backup.sh >> /var/log/cron.log 2>&1" > /etc/crontabs/root
-    echo "[$(date -Iseconds)] Cron schedule '${POSTGRES_BACKUP_CRON}' configured" >> /var/log/cron.log
+    log "Writing cron entry '${POSTGRES_BACKUP_CRON}'"
+    echo "${POSTGRES_BACKUP_CRON} /usr/local/bin/backup.sh >> /proc/1/fd/1 2>&1" > /etc/crontabs/root
+    log "Starting crond in foreground"
     exec crond -f -l 2
     ;;
   backup)
     shift 1 || true
+    log "Running one-off backup"
     exec /usr/local/bin/backup.sh "$@"
     ;;
   restore)
     shift 1 || true
+    log "Running restore"
     exec /usr/local/bin/restore.sh "$@"
     ;;
   *)
+    log "Executing custom command: $*"
     exec "$@"
     ;;
 esac

--- a/scripts/postgres-maintenance/restore.sh
+++ b/scripts/postgres-maintenance/restore.sh
@@ -1,28 +1,43 @@
 #!/bin/sh
 set -euo pipefail
 
+log() {
+  echo "[$(date -Iseconds)] [restore] $*"
+}
+
+cleanup() {
+  status=$?
+  if [ $status -eq 0 ]; then
+    log "Restore completed successfully"
+  else
+    log "Restore failed with exit code $status"
+  fi
+}
+
+log "Starting restore script"
+trap cleanup EXIT
+
 if [ -z "${POSTGRES_BACKUP_FILE:-}" ]; then
-  echo "POSTGRES_BACKUP_FILE is not set" >&2
+  log "POSTGRES_BACKUP_FILE is not set"
   exit 1
 fi
 
 if [ ! -f "${POSTGRES_BACKUP_FILE}" ]; then
-  echo "Backup file ${POSTGRES_BACKUP_FILE} does not exist" >&2
+  log "Backup file ${POSTGRES_BACKUP_FILE} does not exist"
   exit 1
 fi
 
 if [ -z "${POSTGRES_USER:-}" ] || [ -z "${POSTGRES_PASSWORD:-}" ] || [ -z "${POSTGRES_DB:-}" ]; then
-  echo "POSTGRES_USER, POSTGRES_PASSWORD, and POSTGRES_DB must be set" >&2
+  log "POSTGRES_USER, POSTGRES_PASSWORD, and POSTGRES_DB must be set"
   exit 1
 fi
 
 export PGPASSWORD="${POSTGRES_PASSWORD}"
 
+log "Restoring ${POSTGRES_DB} from ${POSTGRES_BACKUP_FILE} on ${POSTGRES_HOST:-postgres}:${POSTGRES_PORT:-5432}"
 psql \
   --host "${POSTGRES_HOST:-postgres}" \
   --port "${POSTGRES_PORT:-5432}" \
   --username "${POSTGRES_USER}" \
   --dbname "${POSTGRES_DB}" \
   --file "${POSTGRES_BACKUP_FILE}"
-
-echo "[$(date -Iseconds)] Restore completed from ${POSTGRES_BACKUP_FILE}"


### PR DESCRIPTION
## Summary
- add structured logging to the postgres maintenance backup and restore scripts
- log container startup actions and route cron execution output to container logs

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d938862528832486df1c045ad2dc36