### PR TITLE
Configure Traefik for Cloudflare tunnel TLS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .env
 backups/*
 !backups/.gitkeep
+certs/*
+!certs/.gitkeep

--- a/README.md
+++ b/README.md
@@ -142,6 +142,39 @@ and [Information Extractor](https://docs.n8n.io/integrations/builtin/cluster-nod
 nodes. To keep everything local, just remember to use the Ollama node for your
 language model and Qdrant as your vector store.
 
+## Using a Cloudflare Tunnel with HTTPS
+
+If you are terminating TLS in front of the stack (for example, with a
+Cloudflare Tunnel) you can let Traefik serve your custom certificate instead of
+requesting one from Let’s Encrypt.
+
+1. Place your Cloudflare-issued certificate and private key in the `certs`
+   directory using the filenames `cloudflare.crt` and `cloudflare.key`.
+   The files are mounted read-only into the Traefik container at runtime, so
+   they should remain protected on the host system.
+2. Configure the usual DNS values in your `.env` file so Traefik can match the
+   incoming host header:
+
+   ```bash
+   SUBDOMAIN=my-n8n
+   DOMAIN_NAME=example.com
+   ```
+
+3. Make sure your Cloudflare Tunnel forwards HTTPS traffic to
+   `http://localhost:5678`. Traefik listens on port `5678` inside the Compose
+   project and automatically routes the requests to the n8n container over the
+   internal Docker network.
+4. (Optional) If you need to regenerate or rotate the certificate, replace the
+   files in `certs/` and restart the Traefik service with:
+
+   ```bash
+   docker compose restart traefik
+   ```
+
+With this setup, external clients negotiate HTTPS with your Cloudflare
+certificate, while Traefik proxies the requests to n8n over the secure internal
+network.
+
 ## PostgreSQL backups
 
 The stack now includes a `postgres-maintenance` service that runs a cron job to

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ x-n8n: &service-n8n
   image: n8nio/n8n:latest
   networks: ['demo', 'traefik']
   environment:
-    - N8N_PROTOCOL=http
+    - N8N_PROTOCOL=https
     - N8N_PORT=5678
     - N8N_SECURE_COOKIE=false
     - DB_TYPE=postgresdb
@@ -112,8 +112,6 @@ services:
     hostname: n8n
     container_name: n8n
     restart: unless-stopped
-    ports:
-      - 5678:5678
     volumes:
       - n8n_storage:/home/node/.n8n
       - ./n8n/demo-data:/demo-data
@@ -127,8 +125,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.n8n.rule=Host(`${SUBDOMAIN}.${DOMAIN_NAME}`)
       - traefik.http.routers.n8n.tls=true
-      - traefik.http.routers.n8n.entrypoints=web,websecure
-      - traefik.http.routers.n8n.tls.certresolver=myresolver
+      - traefik.http.routers.n8n.entrypoints=tunnel
       - traefik.http.middlewares.n8n.headers.SSLRedirect=true
       - traefik.http.middlewares.n8n.headers.STSSeconds=315360000
       - traefik.http.middlewares.n8n.headers.browserXSSFilter=true
@@ -145,17 +142,16 @@ services:
     command:
       - "--providers.docker=true"
       - "--providers.docker.exposedbydefault=false"
-      - "--entrypoints.web.address=:80"
-      - "--entrypoints.websecure.address=:443"
-      - "--certificatesresolvers.myresolver.acme.tlschallenge=true"
-      - "--certificatesresolvers.myresolver.acme.email=${LETSENCRYPT_EMAIL}"
-      - "--certificatesresolvers.myresolver.acme.storage=/letsencrypt/acme.json"
+      - "--providers.file.directory=/traefik/dynamic"
+      - "--providers.file.watch=true"
+      - "--entrypoints.tunnel.address=:5678"
+      - "--entrypoints.tunnel.http.tls=true"
     ports:
-      - "80:80"
-      - "443:443"
+      - "5678:5678"
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock:ro"
-      - "./letsencrypt:/letsencrypt"
+      - "./certs:/certs:ro"
+      - "./traefik:/traefik:ro"
     networks:
       - traefik
 

--- a/traefik/dynamic/tls.yml
+++ b/traefik/dynamic/tls.yml
@@ -1,0 +1,4 @@
+tls:
+  certificates:
+    - certFile: /certs/cloudflare.crt
+      keyFile: /certs/cloudflare.key


### PR DESCRIPTION
## Summary
- configure Traefik to terminate HTTPS on port 5678 using a mounted Cloudflare certificate
- update the n8n service labels and protocol to work with the new tunnel entrypoint
- document the custom certificate workflow and add storage for user-provided certs

## Testing
- not run (Docker CLI unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d93cc50a208324b97ed6cc6ecac418